### PR TITLE
Rename 'name' to 'url'

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -99,10 +99,10 @@ title_error = { fg = "#a85361" }
 [filetype]
 rules = [
 	# directories
-	{ name = "*/", fg = "#1f6f88" },
+	{ url = "*/", fg = "#1f6f88" },
 
 	# executables
-	{ name = "*", is = "exec", fg = "#7e9350" },
+	{ url = "*", is = "exec", fg = "#7e9350" },
 
 	# images
 	{ mime = "image/*", fg = "#c2a05c" },
@@ -122,16 +122,16 @@ rules = [
 	{ mime = "text/x-{c,c++}", fg = "#1f6f88" },
 
 	# config files
-	{ name = "*.json", fg = "#c2a05c" },
-	{ name = "*.yml", fg = "#1f6f88" },
-	{ name = "*.toml", fg = "#9464b6" },
+	{ url = "*.json", fg = "#c2a05c" },
+	{ url = "*.yml", fg = "#1f6f88" },
+	{ url = "*.toml", fg = "#9464b6" },
 
 	# special files
-	{ name = "*", is = "orphan", bg = "#0a0e14" },
+	{ url = "*", is = "orphan", bg = "#0a0e14" },
 
 	# dummy files
-	{ name = "*", is = "dummy", bg = "#0a0e14" },
+	{ url = "*", is = "dummy", bg = "#0a0e14" },
 
 	# fallback
-	{ name = "*/", fg = "#1f6f88" },
+	{ url = "*/", fg = "#1f6f88" },
 ]


### PR DESCRIPTION
Recently, Yazi renamed the 'name' to 'url'. In the newest version of Yazi, this causes a config error when loading ayu-dark.yazi

See https://github.com/sxyazi/yazi/pull/3034